### PR TITLE
[ELYEE-12] Wrap the Jakarta Authentication ServerAuthConfig and ServerAuthContext.

### DIFF
--- a/ELYEE_Messages.txt
+++ b/ELYEE_Messages.txt
@@ -1,0 +1,14 @@
+# Message ID allocation for the ELYEE project.
+
+1    - 999     - jakarta-authentication
+1000 - 1999    -
+2000 - 2999    -
+3000 - 3999    -
+4000 - 4999    -
+
+# 3.x Branch 
+
+5000 - 5999    -
+6000 - 6999    -
+7000 - 7999    -
+8000 - 8999    -

--- a/authentication/src/main/java/org/wildfly/security/auth/jaspi/_private/ElytronEEMessages.java
+++ b/authentication/src/main/java/org/wildfly/security/auth/jaspi/_private/ElytronEEMessages.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.jaspi._private;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.logging.annotations.ValidIdRange;
+import org.jboss.logging.annotations.ValidIdRanges;
+
+/**
+ * Log messages and exceptions for Elytron EE.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@MessageLogger(projectCode = "ELYEE", length = 5)
+@ValidIdRanges({
+    @ValidIdRange(min = 1, max = 999)
+})
+public interface ElytronEEMessages extends BasicLogger {
+
+    ElytronEEMessages log = Logger.getMessageLogger(ElytronEEMessages.class, "org.wildfly.security.ee");
+
+    @Message(id = 1, value = "No ThreadLocal CallbackHandler available.")
+    IllegalStateException noThreadLocalCallbackHandler();
+
+
+}

--- a/authentication/src/main/java/org/wildfly/security/auth/jaspi/impl/JaspiAuthenticationContext.java
+++ b/authentication/src/main/java/org/wildfly/security/auth/jaspi/impl/JaspiAuthenticationContext.java
@@ -46,9 +46,12 @@ import org.wildfly.security.evidence.Evidence;
 import org.wildfly.security.evidence.PasswordGuessEvidence;
 import org.wildfly.security.permission.ElytronPermission;
 
+import jakarta.security.auth.message.AuthException;
 import jakarta.security.auth.message.callback.CallerPrincipalCallback;
 import jakarta.security.auth.message.callback.GroupPrincipalCallback;
 import jakarta.security.auth.message.callback.PasswordValidationCallback;
+import jakarta.security.auth.message.config.AuthConfigProvider;
+import jakarta.security.auth.message.config.ServerAuthConfig;
 
 /**
  *
@@ -85,6 +88,11 @@ public class JaspiAuthenticationContext {
             sm.checkPermission(CREATE_AUTH_CONTEXT);
         }
         return new JaspiAuthenticationContext(checkNotNullParam("securityDomain", securityDomain), integrated);
+    }
+
+    public ServerAuthConfig getServerAuthConfig(AuthConfigProvider authConfigProvider, String layer, String appContext)
+            throws AuthException {
+        return WrappingServerAuthConfig.getServerAuthConfig(authConfigProvider, layer, appContext, createCallbackHandler());
     }
 
     public CallbackHandler createCallbackHandler() {

--- a/authentication/src/main/java/org/wildfly/security/auth/jaspi/impl/ThreadLocalCallbackHandler.java
+++ b/authentication/src/main/java/org/wildfly/security/auth/jaspi/impl/ThreadLocalCallbackHandler.java
@@ -16,6 +16,7 @@
 
 package org.wildfly.security.auth.jaspi.impl;
 
+import static org.wildfly.security.auth.jaspi._private.ElytronEEMessages.log;
 import java.io.IOException;
 
 import javax.security.auth.callback.Callback;
@@ -25,7 +26,7 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import org.wildfly.common.function.ExceptionSupplier;
 
 /**
- * A {@code CallbackHanlder} implementation which always delegates to one associated
+ * A {@code CallbackHandler} implementation which always delegates to one associated
  * with a {@code ThreadLocal}.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
@@ -42,7 +43,7 @@ class ThreadLocalCallbackHandler implements CallbackHandler {
         if (delegate == null) {
             // This could only happen if there is an attempt to use the CallbackHandler from
             // a different thread.
-            throw new IllegalStateException("No ThreadLocal CallbackHandler available.");
+            throw log.noThreadLocalCallbackHandler();
         }
 
         delegate.handle(callbacks);

--- a/authentication/src/main/java/org/wildfly/security/auth/jaspi/impl/ThreadLocalCallbackHandler.java
+++ b/authentication/src/main/java/org/wildfly/security/auth/jaspi/impl/ThreadLocalCallbackHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.jaspi.impl;
+
+import java.io.IOException;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
+import org.wildfly.common.function.ExceptionSupplier;
+
+/**
+ * A {@code CallbackHanlder} implementation which always delegates to one associated
+ * with a {@code ThreadLocal}.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class ThreadLocalCallbackHandler implements CallbackHandler {
+
+    private static final ThreadLocalCallbackHandler INSTANCE = new ThreadLocalCallbackHandler();
+
+    private final ThreadLocal<CallbackHandler> delegateLocal = new ThreadLocal<>();
+
+    @Override
+    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+        CallbackHandler delegate = delegateLocal.get();
+        if (delegate == null) {
+            // This could only happen if there is an attempt to use the CallbackHandler from
+            // a different thread.
+            throw new IllegalStateException("No ThreadLocal CallbackHandler available.");
+        }
+
+        delegate.handle(callbacks);
+    }
+
+    <R, E extends Exception> R get(ExceptionSupplier<R, E> supplier, CallbackHandler realHandler) throws E {
+        CallbackHandler original = delegateLocal.get();
+        try {
+            delegateLocal.set(realHandler);
+            return supplier.get();
+        } finally {
+            delegateLocal.set(original);
+        }
+    }
+
+    void run(Runnable runnable, CallbackHandler realHandler) {
+        CallbackHandler original = delegateLocal.get();
+        try {
+            delegateLocal.set(realHandler);
+            runnable.run();
+        } finally {
+            delegateLocal.set(original);
+        }
+    }
+
+    static ThreadLocalCallbackHandler getInstance() {
+        return INSTANCE;
+    }
+
+}

--- a/authentication/src/main/java/org/wildfly/security/auth/jaspi/impl/WrappingServerAuthConfig.java
+++ b/authentication/src/main/java/org/wildfly/security/auth/jaspi/impl/WrappingServerAuthConfig.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.jaspi.impl;
+
+import static org.wildfly.common.Assert.assertNotNull;
+import static org.wildfly.common.Assert.checkNotNullParam;
+
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+
+import jakarta.security.auth.message.AuthException;
+import jakarta.security.auth.message.MessageInfo;
+import jakarta.security.auth.message.config.AuthConfigProvider;
+import jakarta.security.auth.message.config.ServerAuthConfig;
+import jakarta.security.auth.message.config.ServerAuthContext;
+
+/**
+ * A wrapper around {@code ServerAuthConfig} to allow us to use a {@code ThreadLocal} to associate our {@code CallbackHandler}.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class WrappingServerAuthConfig implements ServerAuthConfig {
+
+    private final ThreadLocalCallbackHandler threadLocalHandler;
+    private final CallbackHandler realHandler;
+    private final ServerAuthConfig delegate;
+
+    WrappingServerAuthConfig(ThreadLocalCallbackHandler threadLocalHandler, CallbackHandler realHandler,
+            ServerAuthConfig delegate) {
+        this.threadLocalHandler = checkNotNullParam("threadLocalHandler", threadLocalHandler);
+        this.realHandler = checkNotNullParam("realHandler", realHandler);
+        this.delegate = checkNotNullParam("delegate", delegate);
+    }
+
+    @Override
+    public String getMessageLayer() {
+        return threadLocalHandler.get(delegate::getMessageLayer, realHandler);
+    }
+
+    @Override
+    public String getAppContext() {
+        return threadLocalHandler.get(delegate::getAppContext, realHandler);
+    }
+
+    @Override
+    public String getAuthContextID(MessageInfo messageInfo) {
+        return threadLocalHandler.get(() -> delegate.getAuthContextID(messageInfo), realHandler);
+    }
+
+    @Override
+    public void refresh() {
+        threadLocalHandler.run(delegate::refresh, realHandler);
+    }
+
+    @Override
+    public boolean isProtected() {
+        return threadLocalHandler.get(delegate::isProtected, realHandler);
+    }
+
+    @Override
+    public ServerAuthContext getAuthContext(String authContextID, Subject serviceSubject, Map properties) throws AuthException {
+        ServerAuthContext serverAuthContext = threadLocalHandler
+                .get(() -> delegate.getAuthContext(authContextID, serviceSubject, properties), realHandler);
+
+        return serverAuthContext != null ? new WrappingServerAuthContext(threadLocalHandler, realHandler, serverAuthContext)
+                : null;
+    }
+
+    static ServerAuthConfig getServerAuthConfig(AuthConfigProvider authConfigProvider, String layer, String appContext,
+            CallbackHandler realCallbackHandler) throws AuthException {
+        ThreadLocalCallbackHandler threadLocalHandler = ThreadLocalCallbackHandler.getInstance();
+
+        ServerAuthConfig serverAuthConfig = threadLocalHandler
+                .get(() -> authConfigProvider.getServerAuthConfig(layer, appContext, threadLocalHandler), realCallbackHandler);
+        assertNotNull(serverAuthConfig);
+
+        return new WrappingServerAuthConfig(threadLocalHandler, realCallbackHandler, serverAuthConfig);
+    }
+
+}

--- a/authentication/src/main/java/org/wildfly/security/auth/jaspi/impl/WrappingServerAuthContext.java
+++ b/authentication/src/main/java/org/wildfly/security/auth/jaspi/impl/WrappingServerAuthContext.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.jaspi.impl;
+
+import static org.wildfly.common.Assert.checkNotNullParam;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+
+import jakarta.security.auth.message.AuthException;
+import jakarta.security.auth.message.AuthStatus;
+import jakarta.security.auth.message.MessageInfo;
+import jakarta.security.auth.message.config.ServerAuthContext;
+
+/**
+ * A wrapper around {@code ServerAuthContext} to allow us to use a {@code ThreadLocal} to associate our {@code CallbackHandler}.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class WrappingServerAuthContext implements ServerAuthContext {
+
+    private final ThreadLocalCallbackHandler threadLocalHandler;
+    private final CallbackHandler realHandler;
+    private final ServerAuthContext delegate;
+
+    WrappingServerAuthContext(ThreadLocalCallbackHandler threadLocalHandler, CallbackHandler realHandler,
+            ServerAuthContext delegate) {
+        this.threadLocalHandler = checkNotNullParam("threadLocalHandler", threadLocalHandler);
+        this.realHandler = checkNotNullParam("realHandler", realHandler);
+        this.delegate = checkNotNullParam("delegate", delegate);
+    }
+
+    @Override
+    public AuthStatus validateRequest(MessageInfo messageInfo, Subject clientSubject, Subject serviceSubject)
+            throws AuthException {
+        return threadLocalHandler.get(() -> delegate.validateRequest(messageInfo, clientSubject, serviceSubject), realHandler);
+    }
+
+    @Override
+    public AuthStatus secureResponse(MessageInfo messageInfo, Subject serviceSubject) throws AuthException {
+        return threadLocalHandler.get(() -> delegate.secureResponse(messageInfo, serviceSubject), realHandler);
+    }
+
+    @Override
+    public void cleanSubject(MessageInfo messageInfo, Subject subject) throws AuthException {
+        threadLocalHandler.get(() -> {
+            delegate.cleanSubject(messageInfo, subject);
+            return null;
+        }, realHandler);
+    }
+
+}


### PR DESCRIPTION
This will allow our CallbackHandler to be associated using a ThreadLocal.

https://issues.redhat.com/browse/ELYEE-12