### PR TITLE
[ELYEE-27] Re-authentication after reboot, even though HttpSession are persisted

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.security.elytron>2.0.0.Final</version.org.wildfly.security.elytron>
         <!-- wildfly-elytron-jaspi was removed in Elytron 2.x so need to compare against 1.x -->
-        <compatibility-version>1.18.1.Final</compatibility-version>
+        <compatibility-version>1.20.2.Final</compatibility-version>
                 
         <test.level>INFO</test.level>
         <!-- Checkstyle configuration -->

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.client.config>1.0.1.Final</version.org.wildfly.client.config>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
-        <version.org.wildfly.security.elytron>2.0.0.Beta1</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.0.0.Final</version.org.wildfly.security.elytron>
         <!-- wildfly-elytron-jaspi was removed in Elytron 2.x so need to compare against 1.x -->
         <compatibility-version>1.18.1.Final</compatibility-version>
                 


### PR DESCRIPTION
https://issues.redhat.com/browse/ELYEE-27
https://issues.redhat.com/browse/ELYEE-28

Supersedes https://github.com/wildfly-security/wildfly-elytron-ee/pull/20

Have added commits for the Elytron component upgrades so this can run through CI.