### PR TITLE
ELYEE-30 Change bean class of produced beans

### DIFF
--- a/security/src/main/java/org/wildfly/security/soteria/original/CdiExtension.java
+++ b/security/src/main/java/org/wildfly/security/soteria/original/CdiExtension.java
@@ -121,7 +121,6 @@ public class CdiExtension implements Extension {
 
             identityStoreBeans.add(new CdiProducer<IdentityStore>()
                     .scope(ApplicationScoped.class)
-                    .beanClass(IdentityStore.class)
                     .types(Object.class, IdentityStore.class, EmbeddedIdentityStore.class)
                     .addToId(EmbeddedIdentityStoreDefinition.class)
                     .create(e -> new EmbeddedIdentityStore(embeddedIdentityStoreDefinition))
@@ -134,7 +133,6 @@ public class CdiExtension implements Extension {
 
             identityStoreBeans.add(new CdiProducer<IdentityStore>()
                     .scope(ApplicationScoped.class)
-                    .beanClass(IdentityStore.class)
                     .types(Object.class, IdentityStore.class, DatabaseIdentityStore.class)
                     .addToId(DatabaseIdentityStoreDefinition.class)
                     .create(e -> new DatabaseIdentityStore(
@@ -149,7 +147,6 @@ public class CdiExtension implements Extension {
 
             identityStoreBeans.add(new CdiProducer<IdentityStore>()
                     .scope(ApplicationScoped.class)
-                    .beanClass(IdentityStore.class)
                     .types(Object.class, IdentityStore.class, LdapIdentityStore.class)
                     .addToId(LdapIdentityStoreDefinition.class)
                     .create(e -> new LdapIdentityStore(
@@ -164,7 +161,6 @@ public class CdiExtension implements Extension {
 
             authenticationMechanismBean = new CdiProducer<HttpAuthenticationMechanism>()
                     .scope(ApplicationScoped.class)
-                    .beanClass(BasicAuthenticationMechanism.class)
                     .types(Object.class, HttpAuthenticationMechanism.class, BasicAuthenticationMechanism.class)
                     .addToId(BasicAuthenticationMechanismDefinition.class)
                     .create(e -> new BasicAuthenticationMechanism(
@@ -178,7 +174,6 @@ public class CdiExtension implements Extension {
 
             authenticationMechanismBean = new CdiProducer<HttpAuthenticationMechanism>()
                     .scope(ApplicationScoped.class)
-                    .beanClass(HttpAuthenticationMechanism.class)
                     .types(Object.class, HttpAuthenticationMechanism.class)
                     .addToId(FormAuthenticationMechanismDefinition.class)
                     .create(e -> {
@@ -197,7 +192,6 @@ public class CdiExtension implements Extension {
 
             authenticationMechanismBean = new CdiProducer<HttpAuthenticationMechanism>()
                     .scope(ApplicationScoped.class)
-                    .beanClass(HttpAuthenticationMechanism.class)
                     .types(Object.class, HttpAuthenticationMechanism.class)
                     .addToId(CustomFormAuthenticationMechanismDefinition.class)
                     .create(e -> {
@@ -218,14 +212,12 @@ public class CdiExtension implements Extension {
 
             authenticationMechanismBean = new CdiProducer<HttpAuthenticationMechanism>()
                     .scope(ApplicationScoped.class)
-                    .beanClass(HttpAuthenticationMechanism.class)
                     .types(HttpAuthenticationMechanism.class)
                     .addToId(OpenIdAuthenticationMechanism.class)
                     .create(e -> getBeanReference(OpenIdAuthenticationMechanism.class));
 
             identityStoreBeans.add(new CdiProducer<IdentityStore>()
                     .scope(ApplicationScoped.class)
-                    .beanClass(IdentityStore.class)
                     .types(IdentityStore.class)
                     .addToId(OpenIdIdentityStore.class)
                     .create(e -> getBeanReference(OpenIdIdentityStore.class))
@@ -233,7 +225,6 @@ public class CdiExtension implements Extension {
 
             extraBeans.add(new CdiProducer<OpenIdAuthenticationMechanismDefinition>()
                     .scope(ApplicationScoped.class)
-                    .beanClass(OpenIdAuthenticationMechanismDefinition.class)
                     .types(OpenIdAuthenticationMechanismDefinition.class)
                     .addToId("OpenId Definition")
                     .create(e -> definition)
@@ -267,7 +258,6 @@ public class CdiExtension implements Extension {
             if ("basic".equalsIgnoreCase(loginConfig.getAuthMethod())) {
                 authenticationMechanismBean = new CdiProducer<HttpAuthenticationMechanism>()
                     .scope(ApplicationScoped.class)
-                    .beanClass(BasicAuthenticationMechanism.class)
                     .types(Object.class, HttpAuthenticationMechanism.class, BasicAuthenticationMechanism.class)
                     .addToId(BasicAuthenticationMechanismDefinition.class)
                     .create(e ->
@@ -278,7 +268,6 @@ public class CdiExtension implements Extension {
             } else if ("form".equalsIgnoreCase(loginConfig.getAuthMethod())) {
                 authenticationMechanismBean = new CdiProducer<HttpAuthenticationMechanism>()
                         .scope(ApplicationScoped.class)
-                        .beanClass(HttpAuthenticationMechanism.class)
                         .types(Object.class, HttpAuthenticationMechanism.class)
                         .addToId(FormAuthenticationMechanismDefinition.class)
                         .create(e -> {
@@ -314,7 +303,6 @@ public class CdiExtension implements Extension {
             // Probably can circumvent this using programmatic lookup or Instance injection
             afterBeanDiscovery.addBean()
                 .scope(Dependent.class)
-                .beanClass(OpenIdAuthenticationMechanismDefinition.class)
                 .types(OpenIdAuthenticationMechanismDefinition.class)
                 .id("Null OpenId Definition")
                 .createWith(cc -> null);
@@ -324,7 +312,6 @@ public class CdiExtension implements Extension {
             decorator.decorateBean(
                 new CdiProducer<IdentityStoreHandler>()
                     .scope(ApplicationScoped.class)
-                    .beanClass(IdentityStoreHandler.class)
                     .types(Object.class, IdentityStoreHandler.class)
                     .addToId(IdentityStoreHandler.class)
                     .create(e -> {

--- a/security/src/main/java/org/wildfly/security/soteria/original/CdiProducer.java
+++ b/security/src/main/java/org/wildfly/security/soteria/original/CdiProducer.java
@@ -40,7 +40,7 @@ public class CdiProducer<T> implements Bean<T>, PassivationCapable {
 
     private String id = this.getClass().getName();
     private String name;
-    private Class<?> beanClass = Object.class;
+    private Class<?> beanClass = CdiExtension.class;
     private Set<Type> types = singleton(Object.class);
     private Set<Annotation> qualifiers = unmodifiableSet(asSet(new DefaultAnnotationLiteral(), new AnyAnnotationLiteral()));
     private Class<? extends Annotation> scope = Dependent.class;


### PR DESCRIPTION
`beanClass` attribute of beans is used by Weld to determine how and where to define a proxy class. In WFLY, it is used to determine a module whose CL is then used. Default `beanClass` for synthetic beans is always their extension class. It can be arbitrary class but using this interface means that Weld will try to create the proxy under Jakarta API module which has no Weld dependencies and that will trigger a WARN message.

Related WFLY issue - https://issues.redhat.com/browse/WFLY-17086
Original WFLY PR - https://github.com/wildfly/wildfly/pull/16155

I am not sure if this should also go into `2.x` branch or if it needs a separate issue. Feel free to take it over in any form or shape; I mainly created it as a proposed solution to the original problem :)

CC @Skyllarr