### PR TITLE
[ELYEE-36] ElytronCallerDetailsResolver.getPrincipalsByType does not include subtypes

### DIFF
--- a/security/src/main/java/org/wildfly/security/soteria/integration/ElytronCallerDetailsResolver.java
+++ b/security/src/main/java/org/wildfly/security/soteria/integration/ElytronCallerDetailsResolver.java
@@ -44,7 +44,7 @@ public class ElytronCallerDetailsResolver implements CallerDetailsResolver {
     public <T extends Principal> Set<T> getPrincipalsByType(Class<T> pType) {
         Set<T> principals = new HashSet<>();
         Principal principal = getCallerPrincipal();
-        if (principal.getClass().isAssignableFrom(pType)) {
+        if (pType.isAssignableFrom(principal.getClass())) {
             principals.add(pType.cast(principal));
         }
         return Collections.unmodifiableSet(principals);


### PR DESCRIPTION
https://issues.redhat.com/browse/ELYEE-36 