### PR TITLE
ELYEE-44 Update CI to also run with SE 17 and SE 21

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}-jdk${{ matrix.java }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -9,16 +9,17 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-jdk${{ matrix.java }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        java: ['11', '17', '21']
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{ matrix.java }}
       # ELY-2204 - Temporarily preventing OidcTest from running on macOS since there
       # are intermittent issues with starting up the Docker container.
       #- if: matrix.os == 'macos-latest'

--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -40,7 +40,7 @@
             <plugin>
                 <groupId>com.github.siom79.japicmp</groupId>
                 <artifactId>japicmp-maven-plugin</artifactId>
-                <version>0.13.0</version>
+                <version>0.20.0</version>
                 <inherited>false</inherited>
                 <configuration>
                     <oldVersion>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELYEE-44
https://issues.redhat.com/browse/ELYEE-45
Builds on https://github.com/wildfly-security/wildfly-elytron-ee/pull/29 to update the value of `runs-on` property