### PR TITLE
Fix redirect to logoutURI

### DIFF
--- a/security/src/main/java/org/wildfly/security/soteria/original/OpenIdAuthenticationMechanism.java
+++ b/security/src/main/java/org/wildfly/security/soteria/original/OpenIdAuthenticationMechanism.java
@@ -460,7 +460,7 @@ public class OpenIdAuthenticationMechanism implements HttpAuthenticationMechanis
                 logoutURI.queryParam(POST_LOGOUT_REDIRECT_URI, logout.buildRedirectURI(request));
             }
 
-            redirect(response, logoutURI.toString());
+            redirect(response, logoutURI.build().toString());
         } else if (!isEmpty(logout.getRedirectURI())) {
             redirect(response, logout.buildRedirectURI(request));
         } else {


### PR DESCRIPTION
When a logout redirect uri is specified via LogoutDefinition

@OpenIdAuthenticationMechanismDefinition(
		clientId = "${oidcConfig.clientId}",
		providerURI = "${oidcConfig.providerUri}",
		redirectURI = "${baseURL}/oidc/callback",
		logout = @LogoutDefinition(
			accessTokenExpiry = true,
			notifyProvider = true,
			identityTokenExpiry = true,
			redirectURI = "${baseURL}/oidc/logout"
		)
)
Then the logout URL is built as  "org.jboss.resteasy.specimpl.ResteasyUriBuilderImpl@5396a321" since toString method of the UriBuilder is not guaranteed to return the URL. This might work in some implementations of UriBuilder but not when using the resteasy implementation.

A build() is missing to create a URI Object first.

The issue is also present in the upstream soteria project and should also be fixed there