### PR TITLE
fix(OpenIdAuthenticationMechanism): use build instead of default toString to create logout url

### DIFF
--- a/security/src/main/java/org/wildfly/security/soteria/original/OpenIdAuthenticationMechanism.java
+++ b/security/src/main/java/org/wildfly/security/soteria/original/OpenIdAuthenticationMechanism.java
@@ -460,7 +460,7 @@ public class OpenIdAuthenticationMechanism implements HttpAuthenticationMechanis
                 logoutURI.queryParam(POST_LOGOUT_REDIRECT_URI, logout.buildRedirectURI(request));
             }
 
-            redirect(response, logoutURI.toString());
+            redirect(response, logoutURI.build().toString());
         } else if (!isEmpty(logout.getRedirectURI())) {
             redirect(response, logout.buildRedirectURI(request));
         } else {


### PR DESCRIPTION
UriBuilder.toString() is not implemented and thus does not return a correct url.