### PR TITLE
[ELYEE-57] Typo in method name gePolicyUtil

### DIFF
--- a/authorization/src/main/java/org/wildfly/security/authz/jacc/PolicyUtil.java
+++ b/authorization/src/main/java/org/wildfly/security/authz/jacc/PolicyUtil.java
@@ -49,7 +49,7 @@ public final class PolicyUtil {
         }
     }
 
-    public static PolicyUtil gePolicyUtil() {
+    public static PolicyUtil getPolicyUtil() {
         return new PolicyUtil(getPolicy());
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ELYEE-57