### PR TITLE
[ELYEE-73] Add a mechanism so that the Jakarta Authorization integration can register itself.

### DIFF
--- a/authorization/src/main/java/org/wildfly/security/jakarta/authz/AuthorizarionRegistration.java
+++ b/authorization/src/main/java/org/wildfly/security/jakarta/authz/AuthorizarionRegistration.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.security.jakarta.authz;
+
+/**
+ * Utility to enable registration for Jakarta Authorization.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class AuthorizarionRegistration {
+
+    /**
+     * Perform any static registration for Jakarta Authorization.
+     *
+     * @return {@code true} if successful, {@code false} otherwise.
+     */
+    public static boolean register() {
+        return true;
+    }
+
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ELYEE-73

This PR has been simplified to just support registration for Jakarta Authorization. This new class is no-op in the 3,x branch but the expectation is this will contain initialisation logic in the 4.x branch meaning the subsystem can call it in all situations.
